### PR TITLE
Replace `pkg_resources` with `importlib.resources`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ msgpack = ">= 1.0"
 langcodes = ">= 3.0"
 regex = ">= 2021.7.6"
 ftfy = ">= 6.1"
+importlib_resources = {version = "^6.1.0", python = "<3.10"}
 mecab-python3 = {version = "^1.0.5", optional = true}
 ipadic = {version = "^1.0.0", optional = true}
 mecab-ko-dic = {version = "^1.0.0", optional = true}

--- a/wordfreq/__init__.py
+++ b/wordfreq/__init__.py
@@ -1,4 +1,3 @@
-from pkg_resources import resource_filename
 from functools import lru_cache
 from typing import List, Dict, Iterator, Tuple
 import langcodes
@@ -9,7 +8,13 @@ import pathlib
 import random
 import logging
 import math
+import sys
 import warnings
+
+if sys.version_info < (3, 10):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
 
 from wordfreq.tokens import tokenize, simple_tokenize, lossy_tokenize
 from wordfreq.language_info import get_language_info
@@ -19,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 CACHE_SIZE = 100000
-DATA_PATH = pathlib.Path(resource_filename("wordfreq", "data"))
+DATA_PATH = files("wordfreq") / "data"
 
 # We'll divide the frequency by 10 for each token boundary that was inferred.
 # (We determined the factor of 10 empirically by looking at words in the

--- a/wordfreq/chinese.py
+++ b/wordfreq/chinese.py
@@ -1,12 +1,17 @@
-from pkg_resources import resource_filename
 from typing import List
 import jieba
 import msgpack
 import gzip
+import sys
 
-DICT_FILENAME = resource_filename("wordfreq", "data/jieba_zh.txt")
-ORIG_DICT_FILENAME = resource_filename("wordfreq", "data/jieba_zh_orig.txt")
-SIMP_MAP_FILENAME = resource_filename("wordfreq", "data/_chinese_mapping.msgpack.gz")
+if sys.version_info < (3, 10):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
+
+DICT_FILENAME = files("wordfreq") / "data" / "jieba_zh.txt"
+ORIG_DICT_FILENAME = files("wordfreq") / "data" / "jieba_zh_orig.txt"
+SIMP_MAP_FILENAME = files("wordfreq") / "data" / "_chinese_mapping.msgpack.gz"
 try:
     SIMPLIFIED_MAP = msgpack.load(
         gzip.open(SIMP_MAP_FILENAME), raw=False, strict_map_key=False


### PR DESCRIPTION
`pkg_resources` is removed in Python 3.12, also use backport package `importlib_resources` for older Python versions.